### PR TITLE
Fix "File should be saved first" error

### DIFF
--- a/Modules/Features/GenerateFeature/Sources/GenerateFeature/GenerateFeatureView.swift
+++ b/Modules/Features/GenerateFeature/Sources/GenerateFeature/GenerateFeatureView.swift
@@ -178,7 +178,7 @@ class GenerateFeatureViewModel: ObservableObject {
 }
 
 public struct GenerateFeatureView: View {
-    @StateObject private var viewModel: GenerateFeatureViewModel
+    @ObservedObject private var viewModel: GenerateFeatureViewModel
     let getDocument: () -> PhoenixDocument
     
     public init(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29006153/218414038-ef7bed01-d60c-4a6c-9bed-f0885b379f46.png)

The GenerateFeatureView's view model was not receiving the `fileURL` after the file is saved because it was a `StateObject`. Making it an `ObservedObject` fixes the problem.