### PR TITLE
Fix Validation UI after Generating the Project.

### DIFF
--- a/Modules/Features/GenerateFeature/Sources/GenerateFeature/GenerateFeatureView.swift
+++ b/Modules/Features/GenerateFeature/Sources/GenerateFeature/GenerateFeatureView.swift
@@ -24,6 +24,7 @@ final class GenerateFeatureViewModel: ObservableObject {
     @Published var generateFeatureInput: GenerateFeatureInput? = nil
     @Published var alert: AlertSheetModel? = nil
     let fileURL: URL?
+    let onGenerate: () -> Void
     
     let projectGenerator: ProjectGeneratorProtocol
     let pbxProjectSyncer: PBXProjectSyncerProtocol
@@ -76,8 +77,10 @@ final class GenerateFeatureViewModel: ObservableObject {
     private var generationStart: Date? = nil
     
     public init(fileURL: URL?,
+                onGenerate: @escaping () -> Void,
                 dependencies: GenerateFeatureDependencies) {
         self.fileURL = fileURL
+        self.onGenerate = onGenerate
         
         ashFileURLGetter = AshFileURLGetter(fileURL: fileURL)
         xcodeProjURLGetter = XcodeProjURLGetter(fileURL: fileURL)
@@ -156,6 +159,7 @@ final class GenerateFeatureViewModel: ObservableObject {
             alert = .init(text: "Error generating project: \(error)")
         }
         generateFeatureInput = nil
+        onGenerate()
     }
 
     private func generateXcodeProject(for document: PhoenixDocument, fileURL: URL) throws {
@@ -190,10 +194,12 @@ public struct GenerateFeatureView: View {
     public init(
         fileURL: URL?,
         getDocument: @escaping @autoclosure () -> PhoenixDocument,
+        onGenerate: @escaping () -> Void,
         dependencies: GenerateFeatureDependencies
     ) {
         self._viewModel = .init(wrappedValue: .init(
             fileURL: fileURL,
+            onGenerate: onGenerate,
             dependencies: dependencies
         ))
         self.getDocument = getDocument

--- a/Modules/Features/ValidationFeature/Sources/ValidationFeature/ValidationFeatureView.swift
+++ b/Modules/Features/ValidationFeature/Sources/ValidationFeature/ValidationFeatureView.swift
@@ -23,16 +23,16 @@ final class ValidationFeatureViewModel: ObservableObject {
    
     @Published var state: ValidationState = .loading
     @Published var presentedPopover: ValidationPopover?
-    private var popoverText: String? {
+    private var popoverText: String {
         switch state {
         case .loading:
-            return ""
+            return "Validating Project"
         case .warning(let string):
             return string
         case .error(let string):
             return string
         case .valid:
-            return ""
+            return "Packages and ash file are valid"
         }
     }
     
@@ -107,7 +107,6 @@ final class ValidationFeatureViewModel: ObservableObject {
     }
     
     func onTap() {
-        guard let popoverText else { return }
         self.presentedPopover = .init(text: popoverText)
     }
 }

--- a/Phoenix/ViewModel/ViewModel.swift
+++ b/Phoenix/ViewModel/ViewModel.swift
@@ -160,4 +160,8 @@ final class ViewModel: ObservableObject {
             }
         )
     }
+    
+    func onGenerateCompletion() {
+        objectWillChange.send()
+    }
 }

--- a/Phoenix/Views/ContentView.swift
+++ b/Phoenix/Views/ContentView.swift
@@ -420,6 +420,7 @@ struct ContentView: View {
         GenerateFeatureView(
             fileURL: fileURL,
             getDocument: document,
+            onGenerate: viewModel.onGenerateCompletion,
             dependencies: GenerateFeatureDependencies(
                 dataStore: Container.generateFeatureDataStore(),
                 projectGenerator: Container.projectGenerator(),


### PR DESCRIPTION
This pull request allows the GenerateFeature to notify the main view once the project is generated.
This reloads the Validation UI and fixes the bug where the validation checkmark would be stuck.