### PR TITLE
Creates Resource folders

### DIFF
--- a/Modules/Generators/PackageGenerator/Sources/PackageGenerator/PackageGenerator.swift
+++ b/Modules/Generators/PackageGenerator/Sources/PackageGenerator/PackageGenerator.swift
@@ -26,20 +26,34 @@ public struct PackageGenerator: PackageGeneratorProtocol {
             switch target.type {
             case .executableTarget:
                 try createExecutableSourcesFolderIfNecessary(at: url, name: target.name, importName: package.name)
+                try createResourceFoldersIfNecessary(inFolder: "Sources", at: url, for: target)
             case .target:
                 if package.isMacroPackage {
                     try createMacroPackageSourcesFolderIfNecessary(at: url, name: target.name)
                 } else {
                     try createSourcesFolderIfNecessary(at: url, name: target.name)
                 }
+                try createResourceFoldersIfNecessary(inFolder: "Sources", at: url, for: target)
             case .testTarget:
                 try createTestsFolderIfNecessary(at: url, name: target.name, isMacroPackage: package.isMacroPackage)
+                try createResourceFoldersIfNecessary(inFolder: "Tests", at: url, for: target)
             case .macro:
                 try createMacroSourcesFolderIfNecessary(at: url, name: target.name)
+                try createResourceFoldersIfNecessary(inFolder: "Sources", at: url, for: target)
             }
         }
         try createPackageFile(for: package, at: url)
         try createReadMeFileIfNecessary(at: url, withName: package.name)
+    }
+
+    private func createResourceFoldersIfNecessary(inFolder folder: String, at url: URL, for target: Target) throws {
+        for resource in target.resources {
+            // Resources folder needs to be created inside the right folder for the given Target
+            let newURL = url
+                .appendingPathComponent(folder)
+                .appendingPathComponent(target.name)
+            _ = try createFolderIfNecessary(folder: resource.folderName, at: newURL, withName: "")
+        }
     }
 
     private func createPackageFolderIfNecessary(at url: URL) throws {

--- a/Modules/Generators/PackageGenerator/Sources/PackageGenerator/PackageGenerator.swift
+++ b/Modules/Generators/PackageGenerator/Sources/PackageGenerator/PackageGenerator.swift
@@ -50,52 +50,41 @@ public struct PackageGenerator: PackageGeneratorProtocol {
     }
     
     private func createExecutableSourcesFolderIfNecessary(at url: URL, name: String, importName: String) throws {
-        let path = url.appendingPathComponent("Sources").appendingPathComponent(name, isDirectory: true).path
-        if !fileManager.fileExists(atPath: path) {
-            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
-        }
-
+        let path = try createFolderIfNecessary(folder: "Sources", at: url, withName: name)
         try createExecutableSourceFile(name: "main", atPath: path, importName: importName)
     }
     
     public func createMacroSourcesFolderIfNecessary(at url: URL, name: String) throws {
-        let path = url.appendingPathComponent("Sources").appendingPathComponent(name, isDirectory: true).path
-        if !fileManager.fileExists(atPath: path) {
-            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
-        }
-        
+        let path = try createFolderIfNecessary(folder: "Sources", at: url, withName: name)
         try createMacroSourceFile(name: name, atPath: path)
     }
 
     private func createSourcesFolderIfNecessary(at url: URL, name: String) throws {
-        let path = url.appendingPathComponent("Sources").appendingPathComponent(name, isDirectory: true).path
-        if !fileManager.fileExists(atPath: path) {
-            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
-        }
-
+        let path = try createFolderIfNecessary(folder: "Sources", at: url, withName: name)
         try createSourceFile(name: name, atPath: path)
     }
 
     private func createMacroPackageSourcesFolderIfNecessary(at url: URL, name: String) throws {
-        let path = url.appendingPathComponent("Sources").appendingPathComponent(name, isDirectory: true).path
-        if !fileManager.fileExists(atPath: path) {
-            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
-        }
-
+        let path = try createFolderIfNecessary(folder: "Sources", at: url, withName: name)
         try createMacroPackageSourceFile(name: name, atPath: path)
     }
 
     private func createTestsFolderIfNecessary(at url: URL, name: String, isMacroPackage: Bool) throws {
-        let path = url.appendingPathComponent("Tests").appendingPathComponent(name, isDirectory: true).path
-        if !fileManager.fileExists(atPath: path) {
-            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
-        }
+        let path = try createFolderIfNecessary(folder: "Tests", at: url, withName: name)
 
         if isMacroPackage {
             try createMacroTestFile(name: name, atPath: path)
         } else {
             try createTestFile(name: name, atPath: path)
         }
+    }
+
+    private func createFolderIfNecessary(folder: String, at url: URL, withName name: String) throws -> String {
+        let path = url.appendingPathComponent(folder).appendingPathComponent(name, isDirectory: true).path
+        if !fileManager.fileExists(atPath: path) {
+            try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
+        }
+        return path
     }
 
     private func isDirectoryEmpty(atPath path: String) -> Bool {


### PR DESCRIPTION
### Description

This PR adds the missing logic to create the Resources folders defined in Phoenix and fixes the [following issue](https://github.com/Tawa/Phoenix/issues/76). 

### Implementation

The Resources folder should be created inside the target folder. For the source code target this would be inside "Sources/MyLibrary/Resources". For the test target this would be inside "Tests/MyLibraryTests/Resources".

We also add a `createFoldersIfNecessary` function just to unify all call sites.

### Resources

| Phoenix Package                                                                                                                                                                                                                            | Phoenix Package                                                                                                                                                                                                                            |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
|  <img width="723" alt="Screenshot 2023-11-19 at 12 26 58" src="https://github.com/Tawa/Phoenix/assets/7988482/f5a4dd1e-32ab-425b-9e08-75fea982fe8a"> |  <img width="785" alt="Screenshot 2023-11-19 at 12 27 06" src="https://github.com/Tawa/Phoenix/assets/7988482/f7ff5a3a-3dfd-4256-b5f3-34975c4fa6ed"> |

| Generated Package                                                                                                                                                                                                                          | Generated Package                                                                                                                                                                                                                          |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
|  <img width="267" alt="Screenshot 2023-11-19 at 12 27 49" src="https://github.com/Tawa/Phoenix/assets/7988482/297797f1-9216-4a41-9302-0a4d68d1d4df">  | <img width="282" alt="Screenshot 2023-11-19 at 12 28 24" src="https://github.com/Tawa/Phoenix/assets/7988482/eb634140-0bd5-4743-9532-cbeb89cef2c2">  |




