### PR TITLE
[Feature] Delete LocalDependencies when deleting Component

### DIFF
--- a/Phoenix.xcodeproj/project.pbxproj
+++ b/Phoenix.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		991B1A982ABCA98700B4B8F3 /* PlatformsEditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991B1A972ABCA98700B4B8F3 /* PlatformsEditingView.swift */; };
 		9931609A2AC056E1009981BC /* SectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993160992AC056E1009981BC /* SectionView.swift */; };
 		994957962BF3285E0055B81B /* MutableCollection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994957952BF3285E0055B81B /* MutableCollection+Extensions.swift */; };
+		994957992BF368BB0055B81B /* PhoenixDocument+MutatingExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994957982BF368BB0055B81B /* PhoenixDocument+MutatingExtensionTests.swift */; };
+		9949579B2BF3901D0055B81B /* PhoenixDocument in Frameworks */ = {isa = PBXBuildFile; productRef = 9949579A2BF3901D0055B81B /* PhoenixDocument */; };
+		9949579D2BF390CB0055B81B /* SwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 9949579C2BF390CB0055B81B /* SwiftPackage */; };
 		B20F17412A067ACC004391B0 /* GenerateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20F17402A067ACC004391B0 /* GenerateSheet.swift */; };
 		B20F9D502A0FC1C9005F99BB /* AlertSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20F9D4F2A0FC154005F99BB /* AlertSheet.swift */; };
 		B213A90D28C7CA13005AFC91 /* ProjectGenerator in Frameworks */ = {isa = PBXBuildFile; productRef = B213A90C28C7CA13005AFC91 /* ProjectGenerator */; };
@@ -214,6 +217,7 @@
 		991B1A972ABCA98700B4B8F3 /* PlatformsEditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformsEditingView.swift; sourceTree = "<group>"; };
 		993160992AC056E1009981BC /* SectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionView.swift; sourceTree = "<group>"; };
 		994957952BF3285E0055B81B /* MutableCollection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutableCollection+Extensions.swift"; sourceTree = "<group>"; };
+		994957982BF368BB0055B81B /* PhoenixDocument+MutatingExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PhoenixDocument+MutatingExtensionTests.swift"; sourceTree = "<group>"; };
 		9FE96A2D3B3268D8FAD977D1 /* ProjectValidator */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ProjectValidator; sourceTree = "<group>"; };
 		ABEE0E3F8FE6D1C0124E666E /* AppVersionProvider */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AppVersionProvider; sourceTree = "<group>"; };
 		B0575B2BA782D723A9A8ECFC /* GenerateFeatureDataStoreContract */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = GenerateFeatureDataStoreContract; sourceTree = "<group>"; };
@@ -312,6 +316,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9949579B2BF3901D0055B81B /* PhoenixDocument in Frameworks */,
+				9949579D2BF390CB0055B81B /* SwiftPackage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -421,6 +427,7 @@
 		3873E5B72804C50A000BCB03 /* PhoenixTests */ = {
 			isa = PBXGroup;
 			children = (
+				994957972BF368A70055B81B /* DataStore */,
 				38BCCC9E2854B7D800E928CA /* Files */,
 				38BCCC9C2854B51700E928CA /* PhoenixDocumentParsingTests.swift */,
 			);
@@ -573,6 +580,14 @@
 				BFB2D12C51FEFD765929B0F5 /* PBXProjectSyncerContract */,
 			);
 			path = Syncers;
+			sourceTree = "<group>";
+		};
+		994957972BF368A70055B81B /* DataStore */ = {
+			isa = PBXGroup;
+			children = (
+				994957982BF368BB0055B81B /* PhoenixDocument+MutatingExtensionTests.swift */,
+			);
+			path = DataStore;
 			sourceTree = "<group>";
 		};
 		B20F9D4E2A0FC154005F99BB /* AlertSheet */ = {
@@ -812,6 +827,10 @@
 				3873E5B62804C50A000BCB03 /* PBXTargetDependency */,
 			);
 			name = PhoenixTests;
+			packageProductDependencies = (
+				9949579A2BF3901D0055B81B /* PhoenixDocument */,
+				9949579C2BF390CB0055B81B /* SwiftPackage */,
+			);
 			productName = PhoenixTests;
 			productReference = 3873E5B42804C50A000BCB03 /* PhoenixTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -1017,6 +1036,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				38BCCC9D2854B51700E928CA /* PhoenixDocumentParsingTests.swift in Sources */,
+				994957992BF368BB0055B81B /* PhoenixDocument+MutatingExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1251,6 +1271,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 9;
@@ -1271,7 +1292,7 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUNDLE_LOADER)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Phoenix.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Phoenix";
 			};
 			name = Debug;
 		};
@@ -1280,6 +1301,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 9;
@@ -1299,7 +1321,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUNDLE_LOADER)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Phoenix.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Phoenix";
 			};
 			name = Release;
 		};
@@ -1466,6 +1488,14 @@
 		4B37C4FF2A50B6F600887128 /* LocalFileURLProvider */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = LocalFileURLProvider;
+		};
+		9949579A2BF3901D0055B81B /* PhoenixDocument */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PhoenixDocument;
+		};
+		9949579C2BF390CB0055B81B /* SwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SwiftPackage;
 		};
 		B213A90C28C7CA13005AFC91 /* ProjectGenerator */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Phoenix.xcodeproj/project.pbxproj
+++ b/Phoenix.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		4BF43B022A7E51A300094B27 /* MacroComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF43B012A7E51A300094B27 /* MacroComponentView.swift */; };
 		991B1A982ABCA98700B4B8F3 /* PlatformsEditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991B1A972ABCA98700B4B8F3 /* PlatformsEditingView.swift */; };
 		9931609A2AC056E1009981BC /* SectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993160992AC056E1009981BC /* SectionView.swift */; };
+		994957962BF3285E0055B81B /* MutableCollection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994957952BF3285E0055B81B /* MutableCollection+Extensions.swift */; };
 		B20F17412A067ACC004391B0 /* GenerateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20F17402A067ACC004391B0 /* GenerateSheet.swift */; };
 		B20F9D502A0FC1C9005F99BB /* AlertSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20F9D4F2A0FC154005F99BB /* AlertSheet.swift */; };
 		B213A90D28C7CA13005AFC91 /* ProjectGenerator in Frameworks */ = {isa = PBXBuildFile; productRef = B213A90C28C7CA13005AFC91 /* ProjectGenerator */; };
@@ -212,6 +213,7 @@
 		981295FCE3B52E97779A2186 /* DocumentCoder */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = DocumentCoder; sourceTree = "<group>"; };
 		991B1A972ABCA98700B4B8F3 /* PlatformsEditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformsEditingView.swift; sourceTree = "<group>"; };
 		993160992AC056E1009981BC /* SectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionView.swift; sourceTree = "<group>"; };
+		994957952BF3285E0055B81B /* MutableCollection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutableCollection+Extensions.swift"; sourceTree = "<group>"; };
 		9FE96A2D3B3268D8FAD977D1 /* ProjectValidator */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ProjectValidator; sourceTree = "<group>"; };
 		ABEE0E3F8FE6D1C0124E666E /* AppVersionProvider */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AppVersionProvider; sourceTree = "<group>"; };
 		B0575B2BA782D723A9A8ECFC /* GenerateFeatureDataStoreContract */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = GenerateFeatureDataStoreContract; sourceTree = "<group>"; };
@@ -622,6 +624,7 @@
 			isa = PBXGroup;
 			children = (
 				B2EDFE5D2956F3DD005BB99C /* Array+RemoteComponent+Extensions.swift */,
+				994957952BF3285E0055B81B /* MutableCollection+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -999,6 +1002,7 @@
 				3810D8CD280990AF006E7EE3 /* ComponentsList.swift in Sources */,
 				B2EDFE6229574954005BB99C /* TargetTypesView.swift in Sources */,
 				38E2513F28392D18002FFA31 /* IdentifiableWithTitle.swift in Sources */,
+				994957962BF3285E0055B81B /* MutableCollection+Extensions.swift in Sources */,
 				38BCCC952854A0C000E928CA /* CompositionRoot+RelativeURLProvider.swift in Sources */,
 				B20F9D502A0FC1C9005F99BB /* AlertSheet.swift in Sources */,
 				3853D202283968E1005E2FAE /* RemoteDependencyFormView.swift in Sources */,

--- a/Phoenix/DataStore/PhoenixDocument+MutatingExtension.swift
+++ b/Phoenix/DataStore/PhoenixDocument+MutatingExtension.swift
@@ -142,6 +142,11 @@ extension PhoenixDocument {
         else { return }
         families[familyIndex].components.removeAll(where: { $0.name == name })
         families.removeAll(where: { $0.components.isEmpty })
+        families.modifyEach { componentFamily in
+            componentFamily.components.modifyEach { component in
+                component.localDependencies.removeAll { $0.name == name }
+            }
+        }
     }
     
     mutating func removeRemoteComponent(withURL url: String) {

--- a/Phoenix/Extensions/MutableCollection+Extensions.swift
+++ b/Phoenix/Extensions/MutableCollection+Extensions.swift
@@ -1,0 +1,10 @@
+extension MutableCollection {
+    mutating func modifyEach(_ modify: (inout Element) throws -> Void) rethrows {
+        var i = startIndex
+        while i != endIndex {
+            try modify(&self[i])
+            formIndex(after: &i)
+        }
+
+    }
+}

--- a/PhoenixTests/DataStore/PhoenixDocument+MutatingExtensionTests.swift
+++ b/PhoenixTests/DataStore/PhoenixDocument+MutatingExtensionTests.swift
@@ -1,0 +1,68 @@
+@testable import Phoenix
+import PhoenixDocument
+import XCTest
+
+final class PhoenixDocumentMutatingExtensionTests: XCTestCase {
+    func testRemoveComponentWithName_removesComponentsFromFamilyAndLocalDependencies() {
+        // Given
+        let navigatorName = Name(given: "Navigator", family: "Support")
+        let navigatorComponent = Component(
+            name: navigatorName,
+            defaultLocalization: .init(),
+            platforms: .empty,
+            modules: [:],
+            localDependencies: [],
+            remoteDependencies: [],
+            remoteComponentDependencies: [],
+            macroComponentDependencies: [],
+            resources: [],
+            defaultDependencies: [:]
+        )
+        let supportFamily = ComponentsFamily(
+            family: Family(name: "Support"),
+            components: [navigatorComponent]
+        )
+        let featureFamily = ComponentsFamily(
+            family: Family(name: "Features"),
+            components: [
+                Component(
+                    name: Name(given: "Feature1", family: "Features"),
+                    defaultLocalization: .init(),
+                    platforms: .empty,
+                    modules: [:],
+                    localDependencies: [ComponentDependency(name: navigatorName, targetTypes: [:])],
+                    remoteDependencies: [],
+                    remoteComponentDependencies: [],
+                    macroComponentDependencies: [],
+                    resources: [],
+                    defaultDependencies: [:]
+                ),
+                Component(
+                    name: Name(given: "Feature2", family: "Features"),
+                    defaultLocalization: .init(),
+                    platforms: .empty,
+                    modules: [:],
+                    localDependencies: [ComponentDependency(name: navigatorName, targetTypes: [:])],
+                    remoteDependencies: [],
+                    remoteComponentDependencies: [],
+                    macroComponentDependencies: [],
+                    resources: [],
+                    defaultDependencies: [:]
+                ),
+            ]
+        )
+        var sut = PhoenixDocument(
+            families: [supportFamily, featureFamily]
+        )
+
+        // When
+        sut.removeComponent(withName: navigatorName)
+
+        // Then
+        let components = sut.families.flatMap { $0.components }
+        let localDependencies = components.flatMap { $0.localDependencies }
+        XCTAssertFalse(localDependencies.contains(where: { $0.name.given == "Navigator" }))
+        XCTAssertFalse(components.contains(where: { $0.name.given == "Navigator" }))
+    }
+}
+


### PR DESCRIPTION
### Description

This PR adds perhaps a missing feature where when you delete a component, we also delete the component where it has been referenced as a local dependency. This makes it easier to clean up the dependency by just tapping on generate.

### Changes

We added logic to iterate over all families + components to find Local Dependencies with the same name as the deleted component